### PR TITLE
Fix size store to provide fresh new object on change

### DIFF
--- a/.changeset/forty-months-sniff.md
+++ b/.changeset/forty-months-sniff.md
@@ -1,0 +1,5 @@
+---
+'@threlte/core': patch
+---
+
+fix size store to provide fresh new object on change

--- a/packages/core/src/lib/hooks/useParentSize.ts
+++ b/packages/core/src/lib/hooks/useParentSize.ts
@@ -35,10 +35,9 @@ export const useParentSize = (): {
   const resizeObserver = new ResizeObserver(([entry]) => {
     const { contentRect } = entry
 
-    parentSize.update((value) => {
-      value.width = contentRect.width
-      value.height = contentRect.height
-      return value
+    parentSize.set({
+      width: contentRect.width,
+      height: contentRect.height
     })
   })
 


### PR DESCRIPTION
In Threlte 5, the `size` store provided by `useThrelte` was updated like this in `useParentSize.ts`:
```ts
parentSizeStore.set({
  width: clientWidth,
  height: clientHeight
})
```
In Threlte 6, the update callback is uses the same object and just updates the properties:
```ts
parentSize.update((value) => {
  value.width = contentRect.width
  value.height = contentRect.height
  return value
})
```
This was a suprise for me when upgrading to Threlte 6. I had `<svelte:options immutable />` component that used the threltes's `size` store. When it became mutable svelte did not rerendered my component upon size changes as the value of the `size` store is now always the same object in memory.

This PR makes the behavior consistent with Threlte 5.